### PR TITLE
fix(securit-group): security group was not added in aws_lb resource

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -49,4 +49,5 @@ resource "aws_lb" "vault_lb" {
   load_balancer_type = "network"
   subnets            = var.net_lb_subnet_ids == null ? var.net_vault_subnet_ids : var.net_lb_subnet_ids
   tags               = var.resource_tags
+  security_groups    = [aws_security_group.main[0].id]
 }


### PR DESCRIPTION
## Description
[Provide a brief description of the changes in this PR]

## Related issue
[Link to the related issue (if applicable)]

## Type of change
- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Verified that if the load balancer is created without a security group, assigning one later is not possible, hence the security group must be set during the provisioning stage.
- Manually tested the creation and operation of load balancers with the applied fix to ensure that security groups are properly assigned and functional.
- [Include any additional notes related to the tests]

## Checklist
- [ *] My code follows the style guidelines of this project
- [ *] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ *] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
