### PR TITLE
Fix Retrieval of CA Bundle Secret 

### DIFF
--- a/templates/install-vault.sh.tpl
+++ b/templates/install-vault.sh.tpl
@@ -144,7 +144,7 @@ function fetch_tls_certificates {
 
   %{ if sm_vault_tls_ca_bundle != "NONE" ~}
   log "INFO" "Retrieving CA certificate '${sm_vault_tls_ca_bundle}' from Secrets Manager."
-  aws secretsmanager get-secret-value --secret-id {sm_vault_tls_ca_bundle} --region $REGION --output text --query SecretString > $VAULT_DIR_TLS/ca.pem
+  aws secretsmanager get-secret-value --secret-id ${sm_vault_tls_ca_bundle} --region $REGION --output text --query SecretString > $VAULT_DIR_TLS/ca.pem
   %{ endif ~}
 
   log "INFO" "Setting certificate file permissions and ownership"


### PR DESCRIPTION
## Description
The EC2 user data script fails if the `sm_vault_tls_ca_bundle` input variable is non-null. As a result, instances fail to initialize, and Vault is not installed successfully. The failure is due to an invalid variable reference when retrieving the CA bundle from AWS SecretsManager. This PR fixes that invalid reference.

## Related issue

N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
I deployed the module successfully after updating the invalid reference. The snippet below is output from the user data script that shows the successful retrieval:
```
2024-10-22 20:42:16 [INFO] - Retrieving CA certificate 'arn:aws:secretsmanager:us-east-1:<account>:secret:<id>' from Secrets Manager.
```
The certificate was successfully stored within `/etc/vault.d/tls/ca.pem`, and the server configuration included the `retry_join.leader_ca_cert_file`  as expected:
```
retry_join {
    auto_join        = "provider=aws region=us-east-1 tag_key=aws:autoscaling:groupName tag_value=vault-asg addr_type=private_v4"
    auto_join_scheme = "https"
    leader_ca_cert_file   = "/etc/vault.d/tls/ca.pem"
    leader_tls_servername = "<domain>"
}
```

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
N/A