### PR TITLE
fix(user data template): remove redundant redirection

### DIFF
--- a/templates/install-vault.sh.tpl
+++ b/templates/install-vault.sh.tpl
@@ -137,7 +137,7 @@ function install_vault_plugins {
 # fetch_tls_certificates fetches the TLS certificates from cloud's secret manager
 function fetch_tls_certificates {
   log "INFO" "Retrieving TLS certificate '${sm_vault_tls_cert_arn}' from Secrets Manager."
-  aws secretsmanager get-secret-value --secret-id ${sm_vault_tls_cert_arn} --region $REGION --output text --query SecretString > $VAULT_DIR_TLS/cert.pem > $VAULT_DIR_TLS/cert.pem
+  aws secretsmanager get-secret-value --secret-id ${sm_vault_tls_cert_arn} --region $REGION --output text --query SecretString > $VAULT_DIR_TLS/cert.pem
 
   log "INFO" "Retrieving TLS private key '${sm_vault_tls_cert_key_arn}' from Secrets Manager."
   aws secretsmanager get-secret-value --secret-id ${sm_vault_tls_cert_key_arn} --region $REGION --output text --query SecretString > $VAULT_DIR_TLS/key.pem


### PR DESCRIPTION
## Description
This commit removes the duplicate redirection to the same file, which was likely a copy-paste error. 
The single redirection is sufficient to write the secret value to the cert.pem file.

## Related issue
[Link to the related issue (if applicable)]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- I created a module with this fix.
- This results in a user data without the duplicate redirection in the launch template.
- The secret value is written in the cert.pem file as expected.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
