### PR TITLE
Fix role uniqueness

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,8 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+resource "random_string" "random_6_chars" {
+  length  = 6
+  special = false
+  upper   = true
+  lower   = true
+}
+
 resource "aws_iam_role" "vault_iam_role" {
-  name                 = format("%s-role", var.friendly_name_prefix)
+  name                 = format("%s-role-%s", var.friendly_name_prefix, random_string.random_6_chars.result)
   path                 = var.iam_role_path
   assume_role_policy   = file("${path.module}/templates/vault-server-role.json.tpl")
   permissions_boundary = var.iam_role_permissions_boundary_arn

--- a/templates/install-vault.sh.tpl
+++ b/templates/install-vault.sh.tpl
@@ -317,20 +317,25 @@ exit_script() {
 
 function prepare_disk() {
   local device_name="$1"
-  log "DEBUG" "prepare_disk - device_name; $${device_name}"
+  log "DEBUG" "prepare_disk - device_name: $${device_name}"
 
   local device_mountpoint="$2"
-  log "DEBUG" "prepare_disk - device_mountpoint; $${device_mountpoint}"
+  log "DEBUG" "prepare_disk - device_mountpoint: $${device_mountpoint}"
 
   local device_label="$3"
-  log "DEBUG" "prepare_disk - device_label; $${device_label}"
+  log "DEBUG" "prepare_disk - device_label: $${device_label}"
 
   sleep 20
   local ebs_volume_id=$(aws ec2 describe-volumes --filters Name=attachment.device,Values=$${device_name} Name=attachment.instance-id,Values=$INSTANCE_ID --query 'Volumes[*].{ID:VolumeId}' --region $REGION --output text | tr -d '-' )
-  log "DEBUG" "prepare_disk - ebs_volume_id; $${ebs_volume_id}"
+  log "DEBUG" "prepare_disk - ebs_volume_id: $${ebs_volume_id}"
+
+  if [[ -z "$${ebs_volume_id}" ]]; then
+    log "ERROR" "No EBS volume found attached to device $${device_name}"
+    exit_script 1
+  fi
 
   local device_id=$(readlink -f /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_$${ebs_volume_id})
-  log "DEBUG" "prepare_disk - device_id; $${device_id}"
+  log "DEBUG" "prepare_disk - device_id: $${device_id}"
 
   mkdir $device_mountpoint
 

--- a/templates/install-vault.sh.tpl
+++ b/templates/install-vault.sh.tpl
@@ -325,6 +325,7 @@ function prepare_disk() {
   local device_label="$3"
   log "DEBUG" "prepare_disk - device_label; $${device_label}"
 
+  sleep 20
   local ebs_volume_id=$(aws ec2 describe-volumes --filters Name=attachment.device,Values=$${device_name} Name=attachment.instance-id,Values=$INSTANCE_ID --query 'Volumes[*].{ID:VolumeId}' --region $REGION --output text | tr -d '-' )
   log "DEBUG" "prepare_disk - ebs_volume_id; $${ebs_volume_id}"
 


### PR DESCRIPTION
## Description
This PR proposes two changes:
- A unique role name to support users using this mod to deploy multiple Vault instances in one deploy (such as a DR pair, or with Stacks)
- A sleep command before the instantiation of `ebs_volume_id` in the vault-install.sh.tpl file as it was needed on AWS to prevent empty instantiation which broke deploys.
- Minor improvement on logging as semi-colons are used where colons are needed.

## Related issue
NA

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- [Describe the tests you ran to verify your changes]
Deployed six Vault HVD instances in six AWS regions across three geos, multiple times over a week.

Deployment failed where the module attempted to create multiple IAM roles in my account, one for each instance, except this is not allowed as IAM is a global resource. I needed to add a uniqueness to the roles when created as this is more granular than creating one and expecting other deployments to use the one one of the deployments created.

For the Vault install script, the existing script produces a log containing 
```
2024-12-31 14:33:29 [INFO] - Preparing Vault data disk
2024-12-31 14:33:29 [DEBUG] - prepare_disk - device_name; /dev/sdf
2024-12-31 14:33:29 [DEBUG] - prepare_disk - device_mountpoint; /opt/vault
2024-12-31 14:33:29 [DEBUG] - prepare_disk - device_label; vault-data
2024-12-31 14:33:29 [DEBUG] - prepare_disk - ebs_volume_id;            # should instantiate
```
- [Provide any results or outcomes from the tests]
Now, when the disk does not attach, the script correctly exits.
```
2024-12-31 14:33:29 [DEBUG] - prepare_disk - device_name; /dev/sdf
2024-12-31 14:33:29 [DEBUG] - prepare_disk - device_mountpoint; /opt/vault
2024-12-31 14:33:29 [DEBUG] - prepare_disk - device_label; vault-data
2024-12-31 14:33:42 [ERROR] - No EBS volume found attached to device /dev/sdf
2024-12-31 14:33:42 [ERROR] - Vault custom_data script finished with error code 1.
```
- [Include any additional notes related to the tests]
This is a correctly attached log output:
```
2024-12-31 14:34:10 [INFO] - Preparing Vault audit logs disk
2024-12-31 14:34:10 [DEBUG] - prepare_disk - device_name; /dev/sdg
2024-12-31 14:34:11 [DEBUG] - prepare_disk - device_mountpoint; /var/log/vault
2024-12-31 14:34:11 [DEBUG] - prepare_disk - device_label; vault-audit
2024-12-31 14:34:21 [DEBUG] - prepare_disk - ebs_volume_id; vol0843c04ac9144e58a
2024-12-31 14:34:21 [DEBUG] - prepare_disk - device_id; /dev/nvme1n1
```

I have also switched colons in now as well.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
All the install scripts need
- Commenting properly
- Return code assessment and proper handling particularly for disk-integrating commands like `mkdir`.
