### PR TITLE
feat(lb): add toggle for stickiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_net_ingress_vault_cidr_blocks"></a> [net\_ingress\_vault\_cidr\_blocks](#input\_net\_ingress\_vault\_cidr\_blocks) | List of CIDR blocks to allow API access to Vault. | `list(string)` | `[]` | no |
 | <a name="input_net_ingress_vault_security_group_ids"></a> [net\_ingress\_vault\_security\_group\_ids](#input\_net\_ingress\_vault\_security\_group\_ids) | List of CIDR blocks to allow API access to Vault. | `list(string)` | `[]` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | A map containing tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_stickyness_enabled"></a> [stickyness\_enabled](#input\_stickyness\_enabled) | Enable sticky sessions by client IP address for the load balancer. | `bool` | `true` | no |
 | <a name="input_systemd_dir"></a> [systemd\_dir](#input\_systemd\_dir) | Path to systemd directory for unit files | `string` | `"/lib/systemd/system"` | no |
 | <a name="input_vault_default_lease_ttl_duration"></a> [vault\_default\_lease\_ttl\_duration](#input\_vault\_default\_lease\_ttl\_duration) | The default lease TTL expressed as a time duration in hours, minutes and/or seconds (e.g. `4h30m10s`) | `string` | `"1h"` | no |
 | <a name="input_vault_dir_bin"></a> [vault\_dir\_bin](#input\_vault\_dir\_bin) | The bin directory for the Vault binary | `string` | `"/usr/bin"` | no |

--- a/lb.tf
+++ b/lb.tf
@@ -27,6 +27,11 @@ resource "aws_lb_target_group" "vault_api" {
       var.vault_health_endpoints["sealedcode"],
     var.vault_health_endpoints["uninitcode"])
   }
+
+  stickiness {
+    type    = "source_ip" # Only option for NLBs
+    enabled = var.stickiness_enabled
+  }
 }
 
 resource "aws_lb_listener" "vault_api" {

--- a/variables.tf
+++ b/variables.tf
@@ -453,3 +453,9 @@ variable "health_check_deregistration_delay" {
     error_message = "The health check deregistration delay must be between 0 and 3600."
   }
 }
+
+variable "stickiness_enabled" {
+  type        = bool
+  description = "Enable sticky sessions by client IP address for the load balancer."
+  default     = true
+}


### PR DESCRIPTION
## Description
Enable user configuration of load balancer stickiness. The default behavior is to maintain stickiness by client IP, which is consistent with the behavior prior to this variable being introduced. Disabling stickiness can be helpful in certain scenarios, e.g. running `vault-benchmark` from a single client machine and wanting to target all nodes in a Vault cluster equally.

## Related issue
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Ran `terraform validate` on the changes
- Deployed to AWS and confirmed that the target group has stickiness disabled when the variable is set to `false`

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
N/A
