### PR TITLE
feat(compute): enable raft performance multiplier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_vault_port_api"></a> [vault\_port\_api](#input\_vault\_port\_api) | The port the Vault API will listen on | `string` | `"8200"` | no |
 | <a name="input_vault_port_cluster"></a> [vault\_port\_cluster](#input\_vault\_port\_cluster) | The port the Vault cluster port will listen on | `string` | `"8201"` | no |
 | <a name="input_vault_raft_auto_join_tag"></a> [vault\_raft\_auto\_join\_tag](#input\_vault\_raft\_auto\_join\_tag) | A map containing a single tag which will be used by Vault to join other nodes to the cluster. If left blank, the module will use the first entry in `tags` | `map(string)` | `null` | no |
+| <a name="input_vault_raft_performance_multiplier"></a> [vault\_raft\_performance\_multiplier](#input\_vault\_raft\_performance\_multiplier) | Raft performance multiplier value. Defaults to 0, which is the default Vault value. | `number` | `0` | no |
 | <a name="input_vault_seal_awskms_region"></a> [vault\_seal\_awskms\_region](#input\_vault\_seal\_awskms\_region) | The region the KMS is in. Leave null if in the same region as everything else | `string` | `null` | no |
 | <a name="input_vault_seal_type"></a> [vault\_seal\_type](#input\_vault\_seal\_type) | The seal type to use for Vault | `string` | `"awskms"` | no |
 | <a name="input_vault_snapshots_bucket_arn"></a> [vault\_snapshots\_bucket\_arn](#input\_vault\_snapshots\_bucket\_arn) | The ARN of the S3 bucket for auto-snapshots | `string` | `null` | no |

--- a/compute.tf
+++ b/compute.tf
@@ -33,6 +33,7 @@ locals {
     vault_tls_disable_client_certs           = var.vault_tls_disable_client_certs,
     vault_seal_type                          = var.vault_seal_type,
     vault_seal_attributes                    = local.vault_seal_attributes,
+    vault_raft_performance_multiplier        = var.vault_raft_performance_multiplier
 
     vault_plugin_urls   = var.vault_plugin_urls
     auto_join_tag_key   = var.vault_raft_auto_join_tag == null ? "aws:autoscaling:groupName" : keys(var.vault_raft_auto_join_tag)[0],

--- a/templates/install-vault.sh.tpl
+++ b/templates/install-vault.sh.tpl
@@ -181,8 +181,9 @@ listener "tcp" {
 }
 
 storage "raft" {
-  path    = "$VAULT_DIR_DATA"
-  node_id = "$INSTANCE_ID"
+  path                   = "$VAULT_DIR_DATA"
+  node_id                = "$INSTANCE_ID"
+  performance_multiplier = ${vault_raft_performance_multiplier}
 
   autopilot_redundancy_zone = "$AVAILABILITY_ZONE"
 

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,22 @@ variable "vault_raft_auto_join_tag" {
   default     = null
 }
 
+variable "vault_raft_performance_multiplier" {
+  description = "Raft performance multiplier value. Defaults to 0, which is the default Vault value."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.vault_raft_performance_multiplier >= 0 && var.vault_raft_performance_multiplier <= 10
+    error_message = "Raft performance multiplier must be 0 (use Vault default) or an integer between 1 and 10."
+  }
+
+  validation {
+    condition     = var.vault_raft_performance_multiplier == floor(var.vault_raft_performance_multiplier)
+    error_message = "Raft performance multiplier must be an integer."
+  }
+}
+
 #------------------------------------------------------------------------------
 # System paths and settings
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Add a variable to enable user configuration of Vault's Raft performance multiplier.

The [Tune server performance](https://developer.hashicorp.com/vault/docs/concepts/tune-server-performance#performance_multiplier) guide suggests that the default value set by Vault is too lax, and production workloads should set the value to 1 for optimal performance.

## Related issue
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Ran `terraform validate`
- Deployed the module and confirmed that the Launch Template includes the performance multiplier
- Deployed the module and confirmed that Vault nodes start up correctly
- Did _not_ confirm that the actual "live" configuration on the servers matches

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
N/A
