### PR TITLE
manual sync

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -8,7 +8,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: read 
   pull-requests: read
   issues: read
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,14 +96,12 @@ tasks:
       - sh: test -x "$(which gh 2>/dev/null)"
         msg: 'GH CLI required. See https://cli.github.com/.'
       - sh: test -n "{{.MOD_RELEASE}}"
-        msg: 'MOD_RELEASE environment variable required. MOD_RELEASE should be a semver tag like `1.2.3`` and greater than current tag {{.PREV_TAG}}. either pass with `MOD_RELEASE=1.2.3 task release` or set in .env.local file.'
+        msg: 'MOD_RELEASE environment variable required. MOD_RELEASE should be a semver tag like `1.2.3`. Either pass with `MOD_RELEASE=1.2.3 task release` or set in .env.local file.'
     vars:
       MOD_REPO:
         sh: echo "${PWD##*/}"
       REPO_OWNER:
         sh: git config --local remote.origin.url | cut -d':' -f2 | cut -d'/' -f1
-      PREV_TAG:
-        sh: git describe --tags $(git rev-list --tags --max-count=1)
     env:
       MOD_RELEASE: '{{.MOD_RELEASE}}'
     cmds:
@@ -112,38 +110,138 @@ tasks:
         export MOD_RELEASE="{{.MOD_RELEASE}}"
         export REPO_OWNER="{{.REPO_OWNER}}"
         echo "Releasing {{.REPO_OWNER}}/{{.MOD_REPO}} version {{.MOD_RELEASE}}"
-      - git checkout -b rel-${MOD_RELEASE}
+      - git checkout -b release/rc-${MOD_RELEASE}
       - |
         python .github/scripts/markdown-url-converter/markdown-url-converter.py --repo="{{.REPO_OWNER}}/{{.MOD_REPO}}" --release="{{.MOD_RELEASE}}" --overwrite .
-      - git commit  --allow-empty -am "Release version ${MOD_RELEASE}"
-      - git tag -a ${MOD_RELEASE} -m "${MOD_RELEASE} release"
-      - git revert HEAD --no-edit -n
-      - git push origin --tags
-      - git push origin rel-${MOD_RELEASE}
+      - git commit --allow-empty -am "Release version ${MOD_RELEASE}"
       - |
-        gh release create {{.MOD_RELEASE}} \
-        --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
-        --title "{{.MOD_RELEASE}}" \
-        --generate-notes --notes-start-tag {{.PREV_TAG}} --verify-tag
-      - |
-        RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
-        TEMP_FILE=$(mktemp)
-        echo "## v{{.MOD_RELEASE}}" > $TEMP_FILE
-        echo "" >> $TEMP_FILE
-        echo "$RELEASE_NOTES" >> $TEMP_FILE
-        echo "" >> $TEMP_FILE
-        tail -n +1 CHANGELOG.md >> $TEMP_FILE
-        mv $TEMP_FILE CHANGELOG.md
-        git add CHANGELOG.md
-        git commit -m "chore: update CHANGELOG.md for v{{.MOD_RELEASE}}"
-        git push origin rel-${MOD_RELEASE}
-      - |
-        gh pr create \
-        --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
-        --title "Release {{.MOD_RELEASE}}" \
-        --body "Release version {{.MOD_RELEASE}}" \
-        --base main \
-        --head rel-${MOD_RELEASE}
+        MOD_RELEASE_CLEAN="${MOD_RELEASE}"
+        case "$MOD_RELEASE_CLEAN" in
+          [0-9]*.[0-9]*.[0-9]*)
+            case "$MOD_RELEASE_CLEAN" in
+              *[!0-9.]*|*.*.*.*|.*|*..*|*.)
+                echo "MOD_RELEASE must be a semver tag like 1.2.3" >&2
+                exit 1
+                ;;
+            esac
+            ;;
+          *)
+            echo "MOD_RELEASE must be a semver tag like 1.2.3" >&2
+            exit 1
+            ;;
+        esac
 
-      # - git push origin --delete rel-${MOD_RELEASE}
+        RELEASE_DISPLAY="v${MOD_RELEASE_CLEAN}"
+
+        EXISTING_SEMVER_TAGS_RAW="$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+        EXISTING_SEMVER_TAGS_CLEAN="$(printf '%s\n' "$EXISTING_SEMVER_TAGS_RAW" | sed 's/^v//' | sed '/^$/d')"
+
+        if printf '%s\n' "$EXISTING_SEMVER_TAGS_CLEAN" | grep -Fxq "$MOD_RELEASE_CLEAN"; then
+          echo "MOD_RELEASE tag already exists: $MOD_RELEASE_CLEAN" >&2
+          exit 1
+        fi
+
+        LATEST_TAG_CLEAN="$(printf '%s\n' "$EXISTING_SEMVER_TAGS_CLEAN" | sort -V | tail -n 1)"
+        if [ -n "$LATEST_TAG_CLEAN" ] && [ "$(printf '%s\n%s\n' "$LATEST_TAG_CLEAN" "$MOD_RELEASE_CLEAN" | sort -V | tail -n 1)" != "$MOD_RELEASE_CLEAN" ]; then
+          echo "MOD_RELEASE must be greater than the latest existing tag (found: $LATEST_TAG_CLEAN)" >&2
+          exit 1
+        fi
+
+        PREV_TAG=""
+        if [ -n "$LATEST_TAG_CLEAN" ]; then
+          if printf '%s\n' "$EXISTING_SEMVER_TAGS_RAW" | grep -Fxq "v$LATEST_TAG_CLEAN"; then
+            PREV_TAG="v$LATEST_TAG_CLEAN"
+          else
+            PREV_TAG="$LATEST_TAG_CLEAN"
+          fi
+        fi
+
+        RELEASE_NOTES_FILE=$(mktemp)
+        PR_BODY_FILE=$(mktemp)
+        CHANGELOG_TMP_FILE=$(mktemp)
+        trap 'rm -f "$RELEASE_NOTES_FILE" "$PR_BODY_FILE" "$CHANGELOG_TMP_FILE"' EXIT
+
+        if [ -n "$PREV_TAG" ]; then
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/{{.REPO_OWNER}}/{{.MOD_REPO}}/releases/generate-notes" \
+            -f tag_name="{{.MOD_RELEASE}}" \
+            -f previous_tag_name="$PREV_TAG" \
+            --jq '.body' > "$RELEASE_NOTES_FILE"
+        else
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/{{.REPO_OWNER}}/{{.MOD_REPO}}/releases/generate-notes" \
+            -f tag_name="{{.MOD_RELEASE}}" \
+            --jq '.body' > "$RELEASE_NOTES_FILE"
+        fi
+
+        echo "## ${RELEASE_DISPLAY}" > "$CHANGELOG_TMP_FILE"
+        echo "" >> "$CHANGELOG_TMP_FILE"
+        cat "$RELEASE_NOTES_FILE" >> "$CHANGELOG_TMP_FILE"
+        echo "" >> "$CHANGELOG_TMP_FILE"
+        if [ -f CHANGELOG.md ]; then
+          cat CHANGELOG.md >> "$CHANGELOG_TMP_FILE"
+        fi
+        mv "$CHANGELOG_TMP_FILE" CHANGELOG.md
+
+        git add CHANGELOG.md
+        git commit -m "chore: update CHANGELOG.md for ${RELEASE_DISPLAY}"
+
+        git tag -a ${MOD_RELEASE} -m "${MOD_RELEASE} release"
+        git push origin release/rc-${MOD_RELEASE}
+        git push origin refs/tags/${MOD_RELEASE}
+
+        # Wait for the tag to be visible on the remote before creating the release.
+        TAG_VISIBLE="false"
+        i=1
+        while [ "$i" -le 10 ]; do
+          if git ls-remote --tags origin | grep -q "refs/tags/${MOD_RELEASE}$"; then
+            echo "Tag ${MOD_RELEASE} is now available on origin."
+            TAG_VISIBLE="true"
+            break
+          fi
+          echo "Waiting for tag ${MOD_RELEASE} to propagate to origin (attempt ${i}/10)..."
+          sleep 3
+          i=$((i + 1))
+        done
+
+        if [ "$TAG_VISIBLE" != "true" ]; then
+          echo "Tag ${MOD_RELEASE} did not appear on origin after 10 attempts." >&2
+          exit 1
+        fi
+
+        gh release create "{{.MOD_RELEASE}}" \
+          --repo "{{.REPO_OWNER}}/{{.MOD_REPO}}" \
+          --title "{{.MOD_RELEASE}}" \
+          --notes-file "$RELEASE_NOTES_FILE"
+
+        echo "Release version {{.MOD_RELEASE}}" > "$PR_BODY_FILE"
+        echo "" >> "$PR_BODY_FILE"
+        cat "$RELEASE_NOTES_FILE" >> "$PR_BODY_FILE"
+        if ! gh pr create \
+          --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
+          --title "Release {{.MOD_RELEASE}}" \
+          --body-file "$PR_BODY_FILE" \
+          --base main \
+          --head release/rc-${MOD_RELEASE}; then
+          # If PR creation failed, check whether an open PR from this branch already exists.
+          if gh pr list \
+            --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
+            --head "release/rc-${MOD_RELEASE}" \
+            --state open \
+            --json number \
+            --jq '.[0].number' >/dev/null 2>&1; then
+            echo "Pull request from release/rc-${MOD_RELEASE} already exists; continuing."
+          else
+            echo "Failed to create pull request for release/rc-${MOD_RELEASE}." >&2
+            exit 1
+          fi
+        fi
+
+      # Note: release/rc-${MOD_RELEASE} branches are preserved after creating the PR.
+      # To clean up after the release PR has been merged, delete the branch manually:
+      #   git push origin --delete release/rc-${MOD_RELEASE}
       - git checkout main


### PR DESCRIPTION
This pull request updates `.github/workflows/jira-sync.yml` and `Taskfile.yml` by syncing them from the [hvd-module-template](https://github.com/hashicorp/hvd-module-template) after the automated Template Sync action failed.

**Changes:**

* Restricts GitHub Actions workflow permissions in `.github/workflows/jira-sync.yml` to read-only for `contents`, `pull-requests`, and `issues`, reducing unnecessary write access.
* Updates `Taskfile.yml` release task with strict semantic versioning enforcement, duplicate/out-of-order release prevention, auto-generated changelog updates, and improved release PR creation.

See [terraform-aws-terraform-enterprise-eks-hvd#45](https://github.com/hashicorp/terraform-aws-terraform-enterprise-eks-hvd/pull/45) for reference.